### PR TITLE
ci(codeql): restore javascript scan category

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,10 @@ jobs:
         include:
           - language: javascript-typescript
             build-mode: none
+            category: /language:javascript
           - language: python
             build-mode: none
+            category: /language:python
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -97,4 +99,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{matrix.language}}"
+          category: ${{ matrix.category }}


### PR DESCRIPTION
## Summary
- keep CodeQL analyzing JavaScript with the supported javascript-typescript language key
- upload that job under /language:javascript so it refreshes GitHub's stale language:javascript code-scanning status entry
- make the Python category explicit too

## Evidence
The latest main JavaScript job succeeded and uploaded SARIF, but it used the /language:javascript-typescript category while GitHub is warning about language:javascript.

## Validation
- npx prettier --check .github/workflows/codeql.yml
- npm run build